### PR TITLE
Update UIntOrEmpty.h

### DIFF
--- a/cmod/include/UIntOrEmpty.h
+++ b/cmod/include/UIntOrEmpty.h
@@ -35,8 +35,10 @@ namespace nvhls {
 struct EmptyField : public nvhls_message {
   template <typename T>
   EmptyField operator=(T const &) {
+#ifndef __SYNTHESIS__
     NVHLS_ASSERT_MSG(true,"EmptyField should never be assigned or accessed");   // If an assignment actually occurs during runtime
                                                                                 // you've done something wrong
+#endif
     return EmptyField();
   }
   uint64 to_uint64() { return 0; }


### PR DESCRIPTION
HLS should not see the NVHLS_ASSERT_MSG since it causes HLS compile failures and is intended only for pre-HLS simulation.