### PR TITLE
Update regress_Makefile

### DIFF
--- a/cmod/regress_Makefile
+++ b/cmod/regress_Makefile
@@ -50,8 +50,7 @@ DESIGNS ?= 	unittests/ArbiterModule \
 						examples/ConnectionsRecipes/Adder4 \
 						examples/Counter \
 
-SKIP_DESIGNS ?= \
-						examples/ConnectionsRecipes/Adder3 \
+SKIP_DESIGNS ?= 
 
 RUN_DESIGNS := $(filter-out $(SKIP_DESIGNS),$(DESIGNS))
 


### PR DESCRIPTION
removed Adder3 from SKIP_DESIGNS since annotation port name issue is now fixed in annotate.h